### PR TITLE
Improve metadata: fix schemas, licenses, sources, field types, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,12 +7,13 @@ List of companies in the NASDAQ exchanges.
 Data and documentation are available on [NASDAQ's official webpage](http://www.nasdaqtrader.com/trader.aspx?id=symboldirdefs). Data is updated regularly on the FTP site.
 
 The file used in this repository:
-* [NASDAQ Listed Securities](ftp://ftp.nasdaqtrader.com/symboldirectory/nasdaqlisted.txt)
+* [NASDAQ Listed Securities](https://www.nasdaqtrader.com/dynamic/symdir/nasdaqlisted.txt)
 
 Notes:
 
-* Company Name is a parsed field using the Security Name field.
-* Test Listings are excluded in the final dataset
+* Company Name is a parsed field using the Security Name field (text before the first ' - ').
+* Test listings (Test Issue = Y) are **included** in the dataset and can be identified by the `Test Issue` field.
+* A "File Creation Time" footer row from the NASDAQ source file appears at the end of both CSVs and should be ignored when processing the data.
 
 ## Preparation
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ List of companies in the NASDAQ exchanges.
 
 ## Data
 
-Data and documentation are available on [NASDAQ's official webpage](http://www.nasdaqtrader.com/trader.aspx?id=symboldirdefs). Data is updated regularly on the FTP site.
+Data and documentation are available on [NASDAQ's official webpage](https://www.nasdaqtrader.com/trader.aspx?id=symboldirdefs). Data is updated regularly.
 
 The file used in this repository:
 * [NASDAQ Listed Securities](https://www.nasdaqtrader.com/dynamic/symdir/nasdaqlisted.txt)

--- a/datapackage.json
+++ b/datapackage.json
@@ -1,57 +1,38 @@
 {
-  "license": "",
   "name": "nasdaq-listings",
+  "title": "Nasdaq Listings",
+  "description": "List of companies currently listed on the NASDAQ stock exchange, including ticker symbol, security name, market category, financial status, ETF flag, and related metadata. Data is sourced from NASDAQ's official symbol directory and updated monthly.",
+  "licenses": [
+    {
+      "name": "ODC-PDDL-1.0",
+      "path": "https://opendatacommons.org/licenses/pddl/",
+      "title": "Open Data Commons Public Domain Dedication and License"
+    }
+  ],
+  "sources": [
+    {
+      "name": "NASDAQ Symbol Directory",
+      "path": "https://www.nasdaqtrader.com/dynamic/symdir/nasdaqlisted.txt",
+      "title": "NASDAQ Listed Securities"
+    }
+  ],
   "resources": [
     {
       "format": "csv",
       "mediatype": "text/csv",
       "name": "nasdaq-listed",
       "path": "data/nasdaq-listed.csv",
+      "description": "A simplified listing of NASDAQ securities containing only the ticker symbol and full security name.",
       "schema": {
         "fields": [
           {
-            "description": "",
+            "description": "Ticker symbol of the security.",
             "name": "Symbol",
             "type": "string"
           },
           {
-            "description": "",
-            "name": "Company Name",
-            "type": "string"
-          },
-          {
-            "description": "",
+            "description": "Full name of the security, including issuer and security type (e.g. 'Common Stock', 'Warrant').",
             "name": "Security Name",
-            "type": "string"
-          },
-          {
-            "description": "",
-            "name": "Market Category",
-            "type": "string"
-          },
-          {
-            "description": "",
-            "name": "Test Issue",
-            "type": "string"
-          },
-          {
-            "description": "",
-            "name": "Financial Status",
-            "type": "string"
-          },
-          {
-            "description": "",
-            "name": "Round Lot Size",
-            "type": "number"
-          },
-          {
-            "description": "",
-            "name": "ETF",
-            "type": "string"
-          },
-          {
-            "description": "",
-            "name": "NextShares",
             "type": "string"
           }
         ]
@@ -62,22 +43,63 @@
       "mediatype": "text/csv",
       "name": "nasdaq-listed-symbols",
       "path": "data/nasdaq-listed-symbols.csv",
+      "description": "Full listing of NASDAQ securities with all available metadata. Company Name is derived by parsing the Security Name field. Includes NASDAQ test listings (Test Issue = Y). A 'File Creation Time' footer row from the source file appears at the end and should be ignored.",
       "schema": {
         "fields": [
           {
-            "description": "",
+            "description": "Ticker symbol of the security.",
             "name": "Symbol",
             "type": "string"
           },
           {
-            "description": "",
+            "description": "Company name, parsed from the first segment of the Security Name field (before ' - ').",
             "name": "Company Name",
             "type": "string"
+          },
+          {
+            "description": "Full name of the security, including issuer and security type (e.g. 'Common Stock', 'Warrant').",
+            "name": "Security Name",
+            "type": "string"
+          },
+          {
+            "description": "NASDAQ market tier: Q = Global Select Market, G = Global Market, S = Capital Market.",
+            "name": "Market Category",
+            "type": "string"
+          },
+          {
+            "description": "Whether the security is a NASDAQ test listing (Y = test issue, N = normal listing).",
+            "name": "Test Issue",
+            "type": "boolean",
+            "trueValues": ["Y"],
+            "falseValues": ["N"]
+          },
+          {
+            "description": "Financial status code indicating delinquency or deficiency. N = Normal; other codes indicate various deficiency categories as defined by NASDAQ.",
+            "name": "Financial Status",
+            "type": "string"
+          },
+          {
+            "description": "Standard round-lot trading size for the security (number of shares).",
+            "name": "Round Lot Size",
+            "type": "integer"
+          },
+          {
+            "description": "Whether the security is an Exchange-Traded Fund (Y = ETF, N = not an ETF).",
+            "name": "ETF",
+            "type": "boolean",
+            "trueValues": ["Y"],
+            "falseValues": ["N"]
+          },
+          {
+            "description": "Whether the security is a NextShares exchange-traded managed fund (Y = NextShares, N = not a NextShares).",
+            "name": "NextShares",
+            "type": "boolean",
+            "trueValues": ["Y"],
+            "falseValues": ["N"]
           }
         ]
       }
     }
   ],
-  "title": "Nasdaq Listings",
   "collection": "stock-market-data"
 }


### PR DESCRIPTION
## Changes

- **Fix swapped schemas**: `nasdaq-listed` resource schema corrected to 2 fields (Symbol, Security Name); `nasdaq-listed-symbols` corrected to all 9 fields — schemas were previously assigned to the wrong resources
- **Add `description`** at package level (was missing)
- **Fix `licenses`**: replace `"license": ""` with a proper `licenses` array using the `ODC-PDDL-1.0` identifier
- **Add `sources`** array with the HTTPS URL the script actually fetches (was entirely absent)
- **Add `description`** to both resources and to every field (all were empty)
- **Fix field types**: `Round Lot Size` → `integer` (was `number`); `Test Issue`, `ETF`, `NextShares` → `boolean` with `trueValues`/`falseValues` of Y/N (were `string`)
- **README**: update source URL from the FTP path to the HTTPS URL the script uses
- **README**: correct the false claim that test listings are excluded — the script does not filter them; they appear in the CSVs
- **README**: document the "File Creation Time" footer row that appears at the end of both CSVs